### PR TITLE
feat: BufWritePost watchdog for incremental DB indexing

### DIFF
--- a/lua/bookwyrm/hooks.lua
+++ b/lua/bookwyrm/hooks.lua
@@ -4,13 +4,42 @@ local M = {}
 local api = require("bookwyrm.api")
 local state = require("bookwyrm.state")
 
+--- Registers (or re-registers) the BufWritePost watchdog for the active notebook.
+---
+--- Creates a dedicated `BookwyrmWatchdog` augroup (clearing any previous registration)
+--- and registers a `BufWritePost` autocmd scoped to the active notebook's markdown files.
+--- If no notebook is active the augroup is still cleared but no autocmd is added.
+function M.setup_watchdog()
+	local group = vim.api.nvim_create_augroup("BookwyrmWatchdog", { clear = true })
+
+	if not state.nb then
+		return
+	end
+
+	local nb = state.nb
+
+	vim.api.nvim_create_autocmd("BufWritePost", {
+		group = group,
+		pattern = nb.root_path .. "/*.md",
+		callback = function(ev)
+			local path = vim.api.nvim_buf_get_name(ev.buf)
+			api.sync_buffer(ev.buf)
+			api.fire("post_sync", { path = path })
+		end,
+	})
+end
+
 function M.setup_context_switcher()
 	vim.api.nvim_create_autocmd("BufEnter", {
 		group = vim.api.nvim_create_augroup("BookwyrmContext", { clear = true }),
 		pattern = "*.md",
 		callback = function()
 			local nb = api.get_notebook_by_path()
+			local prev_id = state.nb and state.nb.id
 			state.set_active(nb)
+			if state.nb and state.nb.id ~= prev_id then
+				M.setup_watchdog()
+			end
 		end,
 	})
 end

--- a/lua/bookwyrm/init.lua
+++ b/lua/bookwyrm/init.lua
@@ -60,6 +60,7 @@ function M.setup(opts)
 
 	if not opts.disable_hooks then
 		hooks.setup_context_switcher()
+		hooks.setup_watchdog()
 	end
 end
 


### PR DESCRIPTION
Implements the BufWritePost autocmd that automatically parses and upserts the current buffer into the database on every save.

## Changes

- Add `setup_watchdog()` to `lua/bookwyrm/hooks.lua` with a dedicated `BookwyrmWatchdog` augroup
- Re-register watchdog in `setup_context_switcher` when active notebook changes
- Call `setup_watchdog()` in `init.lua` setup for initial state

Closes #7

Generated with [Claude Code](https://claude.ai/code)