### PR TITLE
feat: mini.pick integration — note, notebook, and backlink pickers

### DIFF
--- a/lua/bookwyrm/pickers/mini.lua
+++ b/lua/bookwyrm/pickers/mini.lua
@@ -11,16 +11,12 @@
 ---   require("bookwyrm.pickers.mini").find_notes()
 local M = {}
 
---- Returns true when mini.pick is available, false (and notifies) otherwise.
+--- Returns true when mini.pick is available, false otherwise.
 ---
 --- @return boolean
 local function has_mini_pick()
 	local ok = pcall(require, "mini.pick")
-	if not ok then
-		require("bookwyrm.util.notify").error("mini.pick is not installed")
-		return false
-	end
-	return true
+	return ok
 end
 
 --- Opens a mini.pick session for searching and opening notes.
@@ -28,21 +24,21 @@ end
 --- Each item's display text includes the note title, aliases, and tags so
 --- mini.pick's fuzzy engine can filter on all three fields.
 ---
---- Key mappings:
----   <CR>    Open the selected note in the current window
----   <C-l>   Insert a [[note title]] wikilink at the calling buffer's cursor
-function M.find_notes()
+--- Selecting a note opens it in the current window.
+--- Press <C-l> to insert a [[note title]] wikilink at the calling buffer's cursor.
+---
+--- @param opts? { mappings?: table } Optional overrides/additions to the picker mappings.
+function M.find_notes(opts)
 	if not has_mini_pick() then
 		return
 	end
+
+	opts = opts or {}
 
 	local MiniPick = require("mini.pick")
 	local api = require("bookwyrm").api
 
 	local notes = api.list_notes()
-	if vim.tbl_isempty(notes) then
-		return
-	end
 
 	-- Capture calling context before the picker takes over the window
 	local caller_buf = vim.api.nvim_get_current_buf()
@@ -72,6 +68,21 @@ function M.find_notes()
 		table.insert(items, { text = display, note = note })
 	end
 
+	local mappings = vim.tbl_deep_extend("force", {
+		insert_link = {
+			char = "<C-l>",
+			func = function()
+				local matches = MiniPick.get_picker_matches()
+				local item = matches and matches.current
+				if item then
+					MiniPick.stop()
+					-- insert_link expects cursor as { row (1-based), col (1-based) }
+					api.insert_link(item.note, caller_buf, { caller_cursor[1], caller_cursor[2] + 1 })
+				end
+			end,
+		},
+	}, opts.mappings or {})
+
 	MiniPick.start({
 		source = {
 			items = items,
@@ -82,20 +93,7 @@ function M.find_notes()
 				end
 			end,
 		},
-		mappings = {
-			insert_link = {
-				char = "<C-l>",
-				func = function()
-					local matches = MiniPick.get_picker_matches()
-					local item = matches and matches.current
-					if item then
-						MiniPick.stop()
-						-- insert_link expects cursor as { row (1-based), col (1-based) }
-						api.insert_link(item.note, caller_buf, { caller_cursor[1], caller_cursor[2] + 1 })
-					end
-				end,
-			},
-		},
+		mappings = mappings,
 	})
 end
 
@@ -103,8 +101,7 @@ end
 ---
 --- Display text shows the notebook name followed by its root path.
 ---
---- Key mappings:
----   <CR>   Set the selected notebook as the active notebook
+--- Selecting a notebook sets it as the active notebook.
 function M.find_notebooks()
 	if not has_mini_pick() then
 		return
@@ -114,9 +111,6 @@ function M.find_notebooks()
 	local api = require("bookwyrm").api
 
 	local notebooks = api.list_notebooks()
-	if vim.tbl_isempty(notebooks) then
-		return
-	end
 
 	local items = {}
 	for _, nb in ipairs(notebooks) do
@@ -144,10 +138,7 @@ end
 --- Display text shows the source note title and, when available, the anchor id
 --- and surrounding link context.
 ---
---- If no backlinks exist, emits an info notification and does not open the picker.
----
---- Key mappings:
----   <CR>   Open the linking note in the current window
+--- Selecting a backlink opens the linking note in the current window.
 function M.find_backlinks()
 	if not has_mini_pick() then
 		return
@@ -158,10 +149,6 @@ function M.find_backlinks()
 
 	local file_path = vim.api.nvim_buf_get_name(0)
 	local backlinks = api.get_backlinks(file_path)
-
-	if vim.tbl_isempty(backlinks) then
-		return
-	end
 
 	local items = {}
 	for _, link in ipairs(backlinks) do

--- a/lua/bookwyrm/pickers/mini.lua
+++ b/lua/bookwyrm/pickers/mini.lua
@@ -25,9 +25,10 @@ end
 --- mini.pick's fuzzy engine can filter on all three fields.
 ---
 --- Selecting a note opens it in the current window.
---- Press <C-l> to insert a [[note title]] wikilink at the calling buffer's cursor.
+--- Press the insert-link key (default: <C-l>) to insert a [[note title]] wikilink
+--- at the calling buffer's cursor.
 ---
---- @param opts? { mappings?: table } Optional overrides/additions to the picker mappings.
+--- @param opts? { insert_link_key?: string } Key to bind to the insert-link action (default: "<C-l>").
 function M.find_notes(opts)
 	if not has_mini_pick() then
 		return
@@ -68,9 +69,9 @@ function M.find_notes(opts)
 		table.insert(items, { text = display, note = note })
 	end
 
-	local mappings = vim.tbl_deep_extend("force", {
+	local mappings = {
 		insert_link = {
-			char = "<C-l>",
+			char = opts.insert_link_key or "<C-l>",
 			func = function()
 				local matches = MiniPick.get_picker_matches()
 				local item = matches and matches.current
@@ -81,7 +82,7 @@ function M.find_notes(opts)
 				end
 			end,
 		},
-	}, opts.mappings or {})
+	}
 
 	MiniPick.start({
 		source = {

--- a/lua/bookwyrm/pickers/mini.lua
+++ b/lua/bookwyrm/pickers/mini.lua
@@ -1,0 +1,197 @@
+--- mini.pick integration for bookwyrm.nvim
+---
+--- Provides pre-baked pickers for notes, notebooks, and backlinks using
+--- echasnovski/mini.pick. Each public function is a standalone picker action
+--- that can be called directly or wired to a user command.
+---
+--- Usage (lazy.nvim example):
+---   require("bookwyrm").setup()
+---   -- Commands like :BookwyrmFind automatically use mini.pick when available.
+---   -- Or call directly:
+---   require("bookwyrm.pickers.mini").find_notes()
+local M = {}
+
+--- Returns true when mini.pick is available, false (and notifies) otherwise.
+---
+--- @return boolean
+local function has_mini_pick()
+	local ok = pcall(require, "mini.pick")
+	if not ok then
+		vim.notify("[bookwyrm] mini.pick is not installed", vim.log.levels.ERROR)
+		return false
+	end
+	return true
+end
+
+--- Opens a mini.pick session for searching and opening notes.
+---
+--- Each item's display text includes the note title, aliases, and tags so
+--- mini.pick's fuzzy engine can filter on all three fields.
+---
+--- Key mappings:
+---   <CR>    Open the selected note in the current window
+---   <C-l>   Insert a [[note title]] wikilink at the calling buffer's cursor
+function M.find_notes()
+	if not has_mini_pick() then
+		return
+	end
+
+	local MiniPick = require("mini.pick")
+	local api = require("bookwyrm").api
+	local notify = require("bookwyrm.util.notify")
+
+	local notes = api.list_notes()
+	if vim.tbl_isempty(notes) then
+		notify.info("No notes found in active notebook")
+		return
+	end
+
+	-- Capture calling context before the picker takes over the window
+	local caller_buf = vim.api.nvim_get_current_buf()
+	local caller_cursor = vim.api.nvim_win_get_cursor(0) -- { row (1-based), col (0-based) }
+
+	-- Build display items: title + aliases + tags so fuzzy engine searches all three
+	local items = {}
+	for _, note in ipairs(notes) do
+		local aliases = {}
+		for _, a in ipairs(note.aliases or {}) do
+			table.insert(aliases, a.alias)
+		end
+
+		local tags = {}
+		for _, t in ipairs(note.tags or {}) do
+			table.insert(tags, t.tag)
+		end
+
+		local display = note.title
+		if #aliases > 0 then
+			display = display .. "  [" .. table.concat(aliases, ", ") .. "]"
+		end
+		if #tags > 0 then
+			display = display .. "  #" .. table.concat(tags, " #")
+		end
+
+		table.insert(items, { text = display, note = note })
+	end
+
+	MiniPick.start({
+		source = {
+			items = items,
+			name = "Bookwyrm Notes",
+			choose = function(item)
+				if item then
+					api.open_note(item.note)
+				end
+			end,
+		},
+		mappings = {
+			insert_link = {
+				char = "<C-l>",
+				func = function()
+					local matches = MiniPick.get_picker_matches()
+					local item = matches and matches.current
+					if item then
+						MiniPick.stop()
+						-- insert_link expects cursor as { row (1-based), col (1-based) }
+						api.insert_link(item.note, caller_buf, { caller_cursor[1], caller_cursor[2] + 1 })
+					end
+				end,
+			},
+		},
+	})
+end
+
+--- Opens a mini.pick session for switching the active notebook.
+---
+--- Display text shows the notebook name followed by its root path.
+---
+--- Key mappings:
+---   <CR>   Set the selected notebook as the active notebook
+function M.find_notebooks()
+	if not has_mini_pick() then
+		return
+	end
+
+	local MiniPick = require("mini.pick")
+	local api = require("bookwyrm").api
+	local notify = require("bookwyrm.util.notify")
+
+	local notebooks = api.list_notebooks()
+	if vim.tbl_isempty(notebooks) then
+		notify.info("No notebooks registered")
+		return
+	end
+
+	local items = {}
+	for _, nb in ipairs(notebooks) do
+		table.insert(items, {
+			text = nb.title .. "  " .. nb.root_path,
+			notebook = nb,
+		})
+	end
+
+	MiniPick.start({
+		source = {
+			items = items,
+			name = "Bookwyrm Notebooks",
+			choose = function(item)
+				if item then
+					api.set_active_notebook(item.notebook)
+				end
+			end,
+		},
+	})
+end
+
+--- Opens a mini.pick session showing all notes that link to the current buffer.
+---
+--- Display text shows the source note title and, when available, the anchor id
+--- and surrounding link context.
+---
+--- If no backlinks exist, emits an info notification and does not open the picker.
+---
+--- Key mappings:
+---   <CR>   Open the linking note in the current window
+function M.find_backlinks()
+	if not has_mini_pick() then
+		return
+	end
+
+	local MiniPick = require("mini.pick")
+	local api = require("bookwyrm").api
+	local notify = require("bookwyrm.util.notify")
+
+	local file_path = vim.api.nvim_buf_get_name(0)
+	local backlinks = api.get_backlinks(file_path)
+
+	if vim.tbl_isempty(backlinks) then
+		notify.info("No backlinks found for current buffer")
+		return
+	end
+
+	local items = {}
+	for _, link in ipairs(backlinks) do
+		local display = link.source_title
+		if link.anchor and link.anchor ~= "" then
+			display = display .. "  ^" .. link.anchor
+		end
+		if link.context and link.context ~= "" then
+			display = display .. "  \xe2\x80\x94 " .. link.context
+		end
+		table.insert(items, { text = display, link = link })
+	end
+
+	MiniPick.start({
+		source = {
+			items = items,
+			name = "Bookwyrm Backlinks",
+			choose = function(item)
+				if item then
+					api.open(item.link.source_path)
+				end
+			end,
+		},
+	})
+end
+
+return M

--- a/lua/bookwyrm/pickers/mini.lua
+++ b/lua/bookwyrm/pickers/mini.lua
@@ -17,7 +17,7 @@ local M = {}
 local function has_mini_pick()
 	local ok = pcall(require, "mini.pick")
 	if not ok then
-		vim.notify("[bookwyrm] mini.pick is not installed", vim.log.levels.ERROR)
+		require("bookwyrm.util.notify").error("mini.pick is not installed")
 		return false
 	end
 	return true
@@ -38,11 +38,9 @@ function M.find_notes()
 
 	local MiniPick = require("mini.pick")
 	local api = require("bookwyrm").api
-	local notify = require("bookwyrm.util.notify")
 
 	local notes = api.list_notes()
 	if vim.tbl_isempty(notes) then
-		notify.info("No notes found in active notebook")
 		return
 	end
 
@@ -114,11 +112,9 @@ function M.find_notebooks()
 
 	local MiniPick = require("mini.pick")
 	local api = require("bookwyrm").api
-	local notify = require("bookwyrm.util.notify")
 
 	local notebooks = api.list_notebooks()
 	if vim.tbl_isempty(notebooks) then
-		notify.info("No notebooks registered")
 		return
 	end
 
@@ -159,13 +155,11 @@ function M.find_backlinks()
 
 	local MiniPick = require("mini.pick")
 	local api = require("bookwyrm").api
-	local notify = require("bookwyrm.util.notify")
 
 	local file_path = vim.api.nvim_buf_get_name(0)
 	local backlinks = api.get_backlinks(file_path)
 
 	if vim.tbl_isempty(backlinks) then
-		notify.info("No backlinks found for current buffer")
 		return
 	end
 
@@ -176,7 +170,7 @@ function M.find_backlinks()
 			display = display .. "  ^" .. link.anchor
 		end
 		if link.context and link.context ~= "" then
-			display = display .. "  \xe2\x80\x94 " .. link.context
+			display = display .. "  — " .. link.context
 		end
 		table.insert(items, { text = display, link = link })
 	end

--- a/plugin/bookwyrm.lua
+++ b/plugin/bookwyrm.lua
@@ -72,6 +72,12 @@ end, { desc = "Open quick capture floating window" })
 -------------------------------------------------------------------------------
 
 vim.api.nvim_create_user_command("BookwyrmFind", function()
+	local mini_ok = pcall(require, "mini.pick")
+	if mini_ok then
+		require("bookwyrm.pickers.mini").find_notes()
+		return
+	end
+
 	local api = require("bookwyrm").api
 	local notify = require("bookwyrm.util.notify")
 	local notes = api.list_notes()
@@ -95,6 +101,12 @@ vim.api.nvim_create_user_command("BookwyrmFind", function()
 end, { desc = "Find a note in the active notebook" })
 
 vim.api.nvim_create_user_command("BookwyrmFindNotebook", function()
+	local mini_ok = pcall(require, "mini.pick")
+	if mini_ok then
+		require("bookwyrm.pickers.mini").find_notebooks()
+		return
+	end
+
 	local api = require("bookwyrm").api
 	local notify = require("bookwyrm.util.notify")
 	local notebooks = api.list_notebooks()
@@ -116,6 +128,12 @@ vim.api.nvim_create_user_command("BookwyrmFindNotebook", function()
 end, { desc = "Switch active notebook" })
 
 vim.api.nvim_create_user_command("BookwyrmBacklinks", function()
+	local mini_ok = pcall(require, "mini.pick")
+	if mini_ok then
+		require("bookwyrm.pickers.mini").find_backlinks()
+		return
+	end
+
 	local api = require("bookwyrm").api
 	local notify = require("bookwyrm.util.notify")
 	local file_path = vim.api.nvim_buf_get_name(0)

--- a/plugin/bookwyrm.lua
+++ b/plugin/bookwyrm.lua
@@ -79,10 +79,8 @@ vim.api.nvim_create_user_command("BookwyrmFind", function()
 	end
 
 	local api = require("bookwyrm").api
-	local notify = require("bookwyrm.util.notify")
 	local notes = api.list_notes()
 	if vim.tbl_isempty(notes) then
-		notify.info("No notes found in active notebook")
 		return
 	end
 
@@ -108,10 +106,8 @@ vim.api.nvim_create_user_command("BookwyrmFindNotebook", function()
 	end
 
 	local api = require("bookwyrm").api
-	local notify = require("bookwyrm.util.notify")
 	local notebooks = api.list_notebooks()
 	if vim.tbl_isempty(notebooks) then
-		notify.info("No notebooks registered")
 		return
 	end
 
@@ -135,12 +131,10 @@ vim.api.nvim_create_user_command("BookwyrmBacklinks", function()
 	end
 
 	local api = require("bookwyrm").api
-	local notify = require("bookwyrm.util.notify")
 	local file_path = vim.api.nvim_buf_get_name(0)
 	local backlinks = api.get_backlinks(file_path)
 
 	if vim.tbl_isempty(backlinks) then
-		notify.info("No backlinks found for current buffer")
 		return
 	end
 


### PR DESCRIPTION
Closes #31

Implements pre-baked mini.pick pickers for bookwyrm.nvim as described in #31.

## Changes

- New `lua/bookwyrm/pickers/mini.lua` module with `find_notes()`, `find_notebooks()`, and `find_backlinks()`
- `BookwyrmFind`, `BookwyrmFindNotebook`, `BookwyrmBacklinks` commands auto-detect mini.pick and use dedicated pickers when available, falling back to `vim.ui.select` otherwise
- `find_notes()` includes custom `<C-l>` mapping to insert a `[[note title]]` wikilink at the calling cursor

Generated with [Claude Code](https://claude.ai/code)