### PR TITLE
fix: hoist notify require to top of plugin/bookwyrm.lua

### DIFF
--- a/plugin/bookwyrm.lua
+++ b/plugin/bookwyrm.lua
@@ -3,8 +3,6 @@ if vim.g.loaded_bookwyrm then
 end
 vim.g.loaded_bookwyrm = true
 
-local notify = require("bookwyrm.util.notify")
-
 vim.api.nvim_create_user_command("BookwyrmSync", function()
 	require("bookwyrm").api.sync()
 end, { desc = "Sync active notebook with filesystem" })
@@ -74,6 +72,7 @@ end, { desc = "Open quick capture floating window" })
 -------------------------------------------------------------------------------
 
 vim.api.nvim_create_user_command("BookwyrmFind", function()
+	local notify = require("bookwyrm.util.notify")
 	local api = require("bookwyrm").api
 	local notes = api.list_notes()
 	if vim.tbl_isempty(notes) then
@@ -96,6 +95,7 @@ vim.api.nvim_create_user_command("BookwyrmFind", function()
 end, { desc = "Find a note in the active notebook" })
 
 vim.api.nvim_create_user_command("BookwyrmFindNotebook", function()
+	local notify = require("bookwyrm.util.notify")
 	local api = require("bookwyrm").api
 	local notebooks = api.list_notebooks()
 	if vim.tbl_isempty(notebooks) then
@@ -116,6 +116,7 @@ vim.api.nvim_create_user_command("BookwyrmFindNotebook", function()
 end, { desc = "Switch active notebook" })
 
 vim.api.nvim_create_user_command("BookwyrmBacklinks", function()
+	local notify = require("bookwyrm.util.notify")
 	local api = require("bookwyrm").api
 	local file_path = vim.api.nvim_buf_get_name(0)
 	local backlinks = api.get_backlinks(file_path)

--- a/plugin/bookwyrm.lua
+++ b/plugin/bookwyrm.lua
@@ -3,6 +3,8 @@ if vim.g.loaded_bookwyrm then
 end
 vim.g.loaded_bookwyrm = true
 
+local notify = require("bookwyrm.util.notify")
+
 vim.api.nvim_create_user_command("BookwyrmSync", function()
 	require("bookwyrm").api.sync()
 end, { desc = "Sync active notebook with filesystem" })
@@ -73,7 +75,6 @@ end, { desc = "Open quick capture floating window" })
 
 vim.api.nvim_create_user_command("BookwyrmFind", function()
 	local api = require("bookwyrm").api
-	local notify = require("bookwyrm.util.notify")
 	local notes = api.list_notes()
 	if vim.tbl_isempty(notes) then
 		notify.info("No notes found in active notebook")
@@ -96,7 +97,6 @@ end, { desc = "Find a note in the active notebook" })
 
 vim.api.nvim_create_user_command("BookwyrmFindNotebook", function()
 	local api = require("bookwyrm").api
-	local notify = require("bookwyrm.util.notify")
 	local notebooks = api.list_notebooks()
 	if vim.tbl_isempty(notebooks) then
 		notify.info("No notebooks registered")
@@ -117,7 +117,6 @@ end, { desc = "Switch active notebook" })
 
 vim.api.nvim_create_user_command("BookwyrmBacklinks", function()
 	local api = require("bookwyrm").api
-	local notify = require("bookwyrm.util.notify")
 	local file_path = vim.api.nvim_buf_get_name(0)
 	local backlinks = api.get_backlinks(file_path)
 


### PR DESCRIPTION
Closes #48

Move the three local `require("bookwyrm.util.notify")` calls from inside individual command callbacks to a single module-level require at the top of the file, consistent with how all other modules handle the util.notify dependency.

Generated with [Claude Code](https://claude.ai/code)