### PR TITLE
feat: allow custom functions as template variables

### DIFF
--- a/lua/bookwyrm/api/notes.lua
+++ b/lua/bookwyrm/api/notes.lua
@@ -26,6 +26,14 @@ local function get_template_variables(extra)
 		time = os.date("%H:%M"),
 	}
 
+	for key, val in pairs(state.cfg.template_variables or {}) do
+		if type(val) == "function" then
+			vars[key] = val()
+		else
+			vars[key] = val
+		end
+	end
+
 	for key, val in pairs(extra or {}) do
 		if type(val) == "function" then
 			vars[key] = val()

--- a/lua/bookwyrm/init.lua
+++ b/lua/bookwyrm/init.lua
@@ -13,6 +13,7 @@ M.api = require("bookwyrm.api")
 --- @field mappings BookwyrmMappings? # Key mapping overrides
 --- @field note_capture BookwyrmCaptureNoteOpts? # Capture note options
 --- @field silent boolean? # If true silences notifications
+--- @field template_variables table<string, string|fun(): string>? # Global template variables (strings or zero-arg functions)
 --- @field templates table<string, BookwyrmNoteTemplate>? # Note templates
 local defaults = {
 	data_path = vim.fn.stdpath("data") .. "/bookwyrm",


### PR DESCRIPTION
Closes #25

Allow users to register custom string or function-based template variables via the `setup()` config. Global variables are merged before per-template variables, preserving existing precedence rules.

Generated with [Claude Code](https://claude.ai/code)