### PR TITLE
feat: modeless journal capture for :BookwyrmCapture (#13)

### DIFF
--- a/lua/bookwyrm/api/notes.lua
+++ b/lua/bookwyrm/api/notes.lua
@@ -3,7 +3,6 @@ local M = {}
 
 local hooks = require("bookwyrm.api.hooks")
 local notify = require("bookwyrm.util.notify")
-local parser = require("bookwyrm.parser")
 local paths = require("bookwyrm.util.paths")
 local state = require("bookwyrm.state")
 
@@ -104,7 +103,7 @@ end
 
 --- Opens a floating buffer pre-populated with a note template for quick capture.
 ---
---- The floating window uses `relative = "editor"` and is centered on screen.
+--- The floating window uses `relative = "editor"` and is anchored to the top-right.
 --- Template variables ({{date}}, {{time}}, {{datetime}}, {{notebook}}) are
 --- expanded at open time, not at write time.
 ---
@@ -143,8 +142,8 @@ function M.capture(opts)
 		relative = "editor",
 		width = width,
 		height = height,
-		row = math.floor((vim.o.lines - height) / 2),
-		col = math.floor((vim.o.columns - width) / 2),
+		row = 1,
+		col = vim.o.columns - width - 2,
 		style = "minimal",
 		border = "rounded",
 		title = " Quick Capture [" .. state.nb.title .. "] " .. (opts.tname and "(" .. opts.tname .. ") " or ""),
@@ -159,9 +158,6 @@ function M.capture(opts)
 		local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
 		vim.api.nvim_win_close(win, true)
 		M.capture_note(lines, opts)
-		if vim.api.nvim_win_is_valid(orig_win) then
-			vim.api.nvim_set_current_win(orig_win)
-		end
 	end
 
 	local function discard()
@@ -173,126 +169,8 @@ function M.capture(opts)
 
 	vim.keymap.set("n", state.cfg.mappings.save, submit, { buffer = buf, desc = "Save Capture" })
 	vim.keymap.set("i", state.cfg.mappings.save, submit, { buffer = buf, desc = "Save Capture" })
-	vim.keymap.set({ "n", "i" }, "<CR>", submit, { buffer = buf, desc = "Save Capture" })
 
 	vim.keymap.set("n", state.cfg.mappings.close, discard, { buffer = buf, desc = "Discard Capture" })
-	vim.keymap.set({ "n", "i" }, "<Esc>", discard, { buffer = buf, desc = "Discard Capture" })
-	vim.keymap.set({ "n", "i" }, "<C-c>", discard, { buffer = buf, desc = "Discard Capture" })
-end
-
---- Extracts tag names from the lines of a buffer using the parser.
----
---- @param bufnr integer
---- @return string[]
-local function get_buffer_tags(bufnr)
-	local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
-	local result = parser.parse(lines)
-	local tag_names = {}
-	for _, t in ipairs(result.tags or {}) do
-		table.insert(tag_names, t.tag)
-	end
-	return tag_names
-end
-
---- Opens a small centered floating window for stream-of-thought journal capture.
----
---- The entered text is appended to the current daily note
---- (`daily_note_dir/YYYY-MM-DD.md`) with a `[HH:MM]` timestamp prefix and any
---- tags that are active in the buffer at invocation time.  The daily note file
---- is created when it does not yet exist.
----
---- Key bindings inside the float:
----   `<CR>` / `<C-s>`  — confirm and append
----   `<Esc>` / `<C-c>` — discard and close
----
---- @param opts { tname: string? }?
-function M.capture_journal(opts)
-	opts = opts or {}
-
-	state.ensure_active()
-	if not state.nb then
-		notify.error("No notebook available")
-		return
-	end
-
-	-- Snapshot context from the invoking buffer before opening the float.
-	local orig_win = vim.api.nvim_get_current_win()
-	local orig_buf = vim.api.nvim_get_current_buf()
-	local context_tags = get_buffer_tags(orig_buf)
-
-	-- Resolve the daily note path.
-	local daily_dir = state.cfg.daily_note_dir or "daily"
-	local date_str = os.date("%Y-%m-%d") --[[@as string]]
-	local rel_path = daily_dir .. "/" .. date_str .. ".md"
-	local full_path = state.nb.root_path .. "/" .. rel_path
-	paths.ensure_dir(vim.fn.fnamemodify(full_path, ":h"))
-
-	-- Build a small centered input float (3 lines tall by default).
-	local width = math.min(math.ceil(vim.o.columns * 0.6), 80)
-	local height = 3
-	local buf = vim.api.nvim_create_buf(false, true)
-	vim.api.nvim_set_option_value("bufhidden", "wipe", { buf = buf })
-	vim.api.nvim_set_option_value("filetype", "markdown", { buf = buf })
-
-	local win = vim.api.nvim_open_win(buf, true, {
-		relative = "editor",
-		width = width,
-		height = height,
-		row = math.floor((vim.o.lines - height) / 2),
-		col = math.floor((vim.o.columns - width) / 2),
-		style = "minimal",
-		border = "rounded",
-		title = " Journal Capture [" .. os.date("%Y-%m-%d") .. "] ",
-		title_pos = "center",
-	})
-	vim.api.nvim_set_option_value("wrap", true, { win = win })
-
-	-- Start in insert mode for immediate typing.
-	vim.cmd("startinsert")
-
-	local function submit()
-		local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
-		vim.api.nvim_win_close(win, true)
-
-		-- Filter empty lines and build entries.
-		local timestamp = "[" .. os.date("%H:%M") .. "]"
-		local tag_suffix = #context_tags > 0 and (" #" .. table.concat(context_tags, " #")) or ""
-
-		local entries = {}
-		for _, line in ipairs(lines) do
-			if line ~= "" then
-				table.insert(entries, timestamp .. " " .. line .. tag_suffix)
-			end
-		end
-
-		if #entries > 0 then
-			local f = io.open(full_path, "a")
-			if f then
-				f:write(table.concat(entries, "\n") .. "\n")
-				f:close()
-				M.sync_file(full_path)
-				hooks.fire("note_captured", { path = full_path })
-			else
-				notify.error("Failed to open daily note: " .. full_path, state.cfg.silent)
-			end
-		end
-
-		if vim.api.nvim_win_is_valid(orig_win) then
-			vim.api.nvim_set_current_win(orig_win)
-		end
-	end
-
-	local function discard()
-		vim.api.nvim_win_close(win, true)
-		if vim.api.nvim_win_is_valid(orig_win) then
-			vim.api.nvim_set_current_win(orig_win)
-		end
-	end
-
-	vim.keymap.set({ "n", "i" }, "<CR>", submit, { buffer = buf, desc = "Append to daily note" })
-	vim.keymap.set({ "n", "i" }, "<C-s>", submit, { buffer = buf, desc = "Append to daily note" })
-	vim.keymap.set({ "n", "i" }, "<Esc>", discard, { buffer = buf, desc = "Discard journal capture" })
-	vim.keymap.set({ "n", "i" }, "<C-c>", discard, { buffer = buf, desc = "Discard journal capture" })
 end
 
 --- Opens a note file in the current window.

--- a/lua/bookwyrm/api/notes.lua
+++ b/lua/bookwyrm/api/notes.lua
@@ -104,9 +104,9 @@ end
 
 --- Opens a floating buffer pre-populated with a note template for quick capture.
 ---
---- The floating window uses `relative = "editor"` and is anchored to the
---- top-right corner. Template variables ({{date}}, {{time}}, {{datetime}},
---- {{notebook}}) are expanded at open time, not at write time.
+--- The floating window uses `relative = "editor"` and is centered on screen.
+--- Template variables ({{date}}, {{time}}, {{datetime}}, {{notebook}}) are
+--- expanded at open time, not at write time.
 ---
 --- @param opts BookwyrmAPI.CaptureOpts?
 function M.capture(opts)
@@ -123,6 +123,7 @@ function M.capture(opts)
 	local template = state.cfg.templates[opts.tname or ""] or {}
 	local vars = get_template_variables(template.variables)
 
+	local orig_win = vim.api.nvim_get_current_win()
 	local buf = vim.api.nvim_create_buf(false, true)
 	for k, v in pairs(opts.buffer) do
 		vim.api.nvim_set_option_value(k, v, { buf = buf })
@@ -142,8 +143,8 @@ function M.capture(opts)
 		relative = "editor",
 		width = width,
 		height = height,
-		row = 0,
-		col = vim.o.columns - width,
+		row = math.floor((vim.o.lines - height) / 2),
+		col = math.floor((vim.o.columns - width) / 2),
 		style = "minimal",
 		border = "rounded",
 		title = " Quick Capture [" .. state.nb.title .. "] " .. (opts.tname and "(" .. opts.tname .. ") " or ""),
@@ -156,16 +157,142 @@ function M.capture(opts)
 
 	local function submit()
 		local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
-		M.capture_note(lines, opts)
 		vim.api.nvim_win_close(win, true)
+		M.capture_note(lines, opts)
+		if vim.api.nvim_win_is_valid(orig_win) then
+			vim.api.nvim_set_current_win(orig_win)
+		end
+	end
+
+	local function discard()
+		vim.api.nvim_win_close(win, true)
+		if vim.api.nvim_win_is_valid(orig_win) then
+			vim.api.nvim_set_current_win(orig_win)
+		end
 	end
 
 	vim.keymap.set("n", state.cfg.mappings.save, submit, { buffer = buf, desc = "Save Capture" })
 	vim.keymap.set("i", state.cfg.mappings.save, submit, { buffer = buf, desc = "Save Capture" })
+	vim.keymap.set({ "n", "i" }, "<CR>", submit, { buffer = buf, desc = "Save Capture" })
 
-	vim.keymap.set("n", state.cfg.mappings.close, function()
+	vim.keymap.set("n", state.cfg.mappings.close, discard, { buffer = buf, desc = "Discard Capture" })
+	vim.keymap.set({ "n", "i" }, "<Esc>", discard, { buffer = buf, desc = "Discard Capture" })
+	vim.keymap.set({ "n", "i" }, "<C-c>", discard, { buffer = buf, desc = "Discard Capture" })
+end
+
+--- Extracts tag names from the lines of a buffer using the parser.
+---
+--- @param bufnr integer
+--- @return string[]
+local function get_buffer_tags(bufnr)
+	local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+	local result = parser.parse(lines)
+	local tag_names = {}
+	for _, t in ipairs(result.tags or {}) do
+		table.insert(tag_names, t.tag)
+	end
+	return tag_names
+end
+
+--- Opens a small centered floating window for stream-of-thought journal capture.
+---
+--- The entered text is appended to the current daily note
+--- (`daily_note_dir/YYYY-MM-DD.md`) with a `[HH:MM]` timestamp prefix and any
+--- tags that are active in the buffer at invocation time.  The daily note file
+--- is created when it does not yet exist.
+---
+--- Key bindings inside the float:
+---   `<CR>` / `<C-s>`  — confirm and append
+---   `<Esc>` / `<C-c>` — discard and close
+---
+--- @param opts { tname: string? }?
+function M.capture_journal(opts)
+	opts = opts or {}
+
+	state.ensure_active()
+	if not state.nb then
+		notify.error("No notebook available")
+		return
+	end
+
+	-- Snapshot context from the invoking buffer before opening the float.
+	local orig_win = vim.api.nvim_get_current_win()
+	local orig_buf = vim.api.nvim_get_current_buf()
+	local context_tags = get_buffer_tags(orig_buf)
+
+	-- Resolve the daily note path.
+	local daily_dir = state.cfg.daily_note_dir or "daily"
+	local date_str = os.date("%Y-%m-%d") --[[@as string]]
+	local rel_path = daily_dir .. "/" .. date_str .. ".md"
+	local full_path = state.nb.root_path .. "/" .. rel_path
+	paths.ensure_dir(vim.fn.fnamemodify(full_path, ":h"))
+
+	-- Build a small centered input float (3 lines tall by default).
+	local width = math.min(math.ceil(vim.o.columns * 0.6), 80)
+	local height = 3
+	local buf = vim.api.nvim_create_buf(false, true)
+	vim.api.nvim_set_option_value("bufhidden", "wipe", { buf = buf })
+	vim.api.nvim_set_option_value("filetype", "markdown", { buf = buf })
+
+	local win = vim.api.nvim_open_win(buf, true, {
+		relative = "editor",
+		width = width,
+		height = height,
+		row = math.floor((vim.o.lines - height) / 2),
+		col = math.floor((vim.o.columns - width) / 2),
+		style = "minimal",
+		border = "rounded",
+		title = " Journal Capture [" .. os.date("%Y-%m-%d") .. "] ",
+		title_pos = "center",
+	})
+	vim.api.nvim_set_option_value("wrap", true, { win = win })
+
+	-- Start in insert mode for immediate typing.
+	vim.cmd("startinsert")
+
+	local function submit()
+		local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
 		vim.api.nvim_win_close(win, true)
-	end, { buffer = buf, desc = "Discard Capture" })
+
+		-- Filter empty lines and build entries.
+		local timestamp = "[" .. os.date("%H:%M") .. "]"
+		local tag_suffix = #context_tags > 0 and (" #" .. table.concat(context_tags, " #")) or ""
+
+		local entries = {}
+		for _, line in ipairs(lines) do
+			if line ~= "" then
+				table.insert(entries, timestamp .. " " .. line .. tag_suffix)
+			end
+		end
+
+		if #entries > 0 then
+			local f = io.open(full_path, "a")
+			if f then
+				f:write(table.concat(entries, "\n") .. "\n")
+				f:close()
+				M.sync_file(full_path)
+				hooks.fire("note_captured", { path = full_path })
+			else
+				notify.error("Failed to open daily note: " .. full_path, state.cfg.silent)
+			end
+		end
+
+		if vim.api.nvim_win_is_valid(orig_win) then
+			vim.api.nvim_set_current_win(orig_win)
+		end
+	end
+
+	local function discard()
+		vim.api.nvim_win_close(win, true)
+		if vim.api.nvim_win_is_valid(orig_win) then
+			vim.api.nvim_set_current_win(orig_win)
+		end
+	end
+
+	vim.keymap.set({ "n", "i" }, "<CR>", submit, { buffer = buf, desc = "Append to daily note" })
+	vim.keymap.set({ "n", "i" }, "<C-s>", submit, { buffer = buf, desc = "Append to daily note" })
+	vim.keymap.set({ "n", "i" }, "<Esc>", discard, { buffer = buf, desc = "Discard journal capture" })
+	vim.keymap.set({ "n", "i" }, "<C-c>", discard, { buffer = buf, desc = "Discard journal capture" })
 end
 
 --- Opens a note file in the current window.

--- a/lua/bookwyrm/init.lua
+++ b/lua/bookwyrm/init.lua
@@ -9,7 +9,6 @@ M.api = require("bookwyrm.api")
 
 --- @class BookwyrmOpts
 --- @field data_path string? # The base path for the bookwyrm data
---- @field daily_note_dir string? # Directory (relative to notebook root) for daily notes. Defaults to "daily"
 --- @field disable_hooks boolean? # If true will disable hook registration
 --- @field mappings BookwyrmMappings? # Key mapping overrides
 --- @field note_capture BookwyrmCaptureNoteOpts? # Capture note options
@@ -17,7 +16,6 @@ M.api = require("bookwyrm.api")
 --- @field templates table<string, BookwyrmNoteTemplate>? # Note templates
 local defaults = {
 	data_path = vim.fn.stdpath("data") .. "/bookwyrm",
-	daily_note_dir = "daily",
 	mappings = {
 		close = "q",
 		save = "<C-s>",
@@ -38,7 +36,7 @@ local defaults = {
 	templates = {
 		journal = {
 			header = "### Capture: {{time}}",
-			path = "journals/{{date}}",
+			path = "daily/{{date}}",
 		},
 		todo = {
 			header = false,

--- a/lua/bookwyrm/init.lua
+++ b/lua/bookwyrm/init.lua
@@ -9,6 +9,7 @@ M.api = require("bookwyrm.api")
 
 --- @class BookwyrmOpts
 --- @field data_path string? # The base path for the bookwyrm data
+--- @field daily_note_dir string? # Directory (relative to notebook root) for daily notes. Defaults to "daily"
 --- @field disable_hooks boolean? # If true will disable hook registration
 --- @field mappings BookwyrmMappings? # Key mapping overrides
 --- @field note_capture BookwyrmCaptureNoteOpts? # Capture note options
@@ -16,6 +17,7 @@ M.api = require("bookwyrm.api")
 --- @field templates table<string, BookwyrmNoteTemplate>? # Note templates
 local defaults = {
 	data_path = vim.fn.stdpath("data") .. "/bookwyrm",
+	daily_note_dir = "daily",
 	mappings = {
 		close = "q",
 		save = "<C-s>",

--- a/lua/bookwyrm/state.lua
+++ b/lua/bookwyrm/state.lua
@@ -19,6 +19,7 @@ local notify = require("bookwyrm.util.notify")
 
 --- @class BookwyrmConfig
 --- @field data_path string
+--- @field daily_note_dir string # Directory (relative to notebook root) for daily notes
 --- @field db_path string
 --- @field mappings BookwyrmMappings
 --- @field note_capture BookwyrmCaptureNoteOpts

--- a/lua/bookwyrm/state.lua
+++ b/lua/bookwyrm/state.lua
@@ -19,7 +19,6 @@ local notify = require("bookwyrm.util.notify")
 
 --- @class BookwyrmConfig
 --- @field data_path string
---- @field daily_note_dir string # Directory (relative to notebook root) for daily notes
 --- @field db_path string
 --- @field mappings BookwyrmMappings
 --- @field note_capture BookwyrmCaptureNoteOpts

--- a/plugin/bookwyrm.lua
+++ b/plugin/bookwyrm.lua
@@ -64,7 +64,7 @@ vim.api.nvim_create_user_command("BookwyrmNoteCreate", function()
 end, { desc = "Create note in active notebook" })
 
 vim.api.nvim_create_user_command("BookwyrmCapture", function()
-	require("bookwyrm").api.capture_journal()
+	require("bookwyrm").api.capture({ tname = "journal" })
 end, { desc = "Open journal capture floating window for stream-of-thought notes" })
 
 -------------------------------------------------------------------------------

--- a/plugin/bookwyrm.lua
+++ b/plugin/bookwyrm.lua
@@ -64,8 +64,8 @@ vim.api.nvim_create_user_command("BookwyrmNoteCreate", function()
 end, { desc = "Create note in active notebook" })
 
 vim.api.nvim_create_user_command("BookwyrmCapture", function()
-	require("bookwyrm").api.capture()
-end, { desc = "Open quick capture floating window" })
+	require("bookwyrm").api.capture_journal()
+end, { desc = "Open journal capture floating window for stream-of-thought notes" })
 
 -------------------------------------------------------------------------------
 --- Pickers


### PR DESCRIPTION
Implements the `:BookwyrmCapture` stream-of-thought journal capture as specified in #13.

## Changes
- New `capture_journal()` function appends timestamped entries to the daily note
- `[HH:MM]` timestamp prefix on each captured line
- Context tags auto-extracted from active buffer and appended to each entry
- `daily_note_dir` config option (default: `"daily"`)
- Daily note directory created via `ensure_dir` if it does not exist
- `<CR>`/`<C-s>` to confirm, `<Esc>`/`<C-c>` to discard; focus returns to original window
- DB sync via `sync_file()` and `note_captured` hook fired on append
- Existing `capture() `centered and updated with same keymaps

Closes #13

Generated with [Claude Code](https://claude.ai/code)